### PR TITLE
[FIX#15] - copy button not working

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,5 +14,5 @@
 //= require jquery-tablesorter
 //= require jquery_ujs
 //= require turbolinks
-//= require_tree .
 //= require zeroclipboard
+//= require copy_clipboard

--- a/app/assets/javascripts/copy_clipboard.coffee
+++ b/app/assets/javascripts/copy_clipboard.coffee
@@ -1,0 +1,8 @@
+$(document).on 'turbolinks:load', ->
+  elem = $("#copy-clipboard-button")
+
+  if elem
+    new ZeroClipboard elem
+
+$(document).on "turbolinks:before-render",  ->
+  ZeroClipboard.destroy()

--- a/app/assets/javascripts/sessions.coffee
+++ b/app/assets/javascripts/sessions.coffee
@@ -1,5 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/
-#
-

--- a/app/assets/javascripts/static_pages.coffee
+++ b/app/assets/javascripts/static_pages.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/stats.coffee
+++ b/app/assets/javascripts/stats.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/users.coffee
+++ b/app/assets/javascripts/users.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -50,8 +50,3 @@
     </div> <!-- navbar-collapse -->
   </div>
 </header>
-<script>
-$(document).ready(function() {
-  var clip = new ZeroClipboard($("#copy-clipboard-button"));
-});
-</script>


### PR DESCRIPTION
Fixes #15 (unable to copy url to clipboard unless page refreshed)

Reason for bug:
Turbolinks wasn't initialising the clipboard properly as we moved through the pages.

Bonus:
Removed empty javascript files.