### PR TITLE
Ignore gen 2 pokemons to keep the app working

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -71,44 +71,47 @@ module SessionsHelper
             count = i[:count]
             user.items.create(item_id: item_id, count: count)
           when :pokemon_data
-            # Set poke_id
-            poke_id = i[:pokemon_id].capitalize.to_s
-            # To deal with Nidoran and Mr. Mime naming
-            poke_id = 'Nidoran♀' if poke_id.match('Nidoran_female')
-            poke_id = 'Nidoran♂' if poke_id.match('Nidoran_male')
-            poke_id = 'Mr. Mime' if poke_id.match('Mr_mime')
-            poke_id = "Farfetch'd" if poke_id.match('Farfetchd')
-            # To deal with MISSINGNO Pokemon
-            if @@pokemon_hash.key(poke_id) != nil
-              poke_num = @@pokemon_hash.key(poke_id)
-            else
-              poke_num = "0"
+            begin
+              # Set poke_id
+              poke_id = i[:pokemon_id].capitalize.to_s
+              # To deal with Nidoran and Mr. Mime naming
+              poke_id = 'Nidoran♀' if poke_id.match('Nidoran_female')
+              poke_id = 'Nidoran♂' if poke_id.match('Nidoran_male')
+              poke_id = 'Mr. Mime' if poke_id.match('Mr_mime')
+              poke_id = "Farfetch'd" if poke_id.match('Farfetchd')
+              # To deal with MISSINGNO Pokemon
+              if @@pokemon_hash.key(poke_id) != nil
+                poke_num = @@pokemon_hash.key(poke_id)
+              else
+                poke_num = "0"
+              end
+              # Instantiate pokemon
+              pokemon = user.pokemon.new
+              # Set data
+              pokemon.poke_id = poke_id
+              pokemon.poke_num = poke_num
+              pokemon.creation_time_ms = i[:creation_time_ms]
+              pokemon.move_1 = i[:move_1]
+              pokemon.move_2 = i[:move_2]
+              pokemon.health = i[:stamina]
+              pokemon.max_health = i[:stamina_max]
+              pokemon.attack = i[:individual_attack]
+              pokemon.defense = i[:individual_defense]
+              pokemon.stamina = i[:individual_stamina]
+              pokemon.cp = i[:cp]
+              pokemon.iv = ((pokemon.attack + pokemon.defense + pokemon.stamina) / 45.0).round(3)
+              pokemon.nickname = i[:nickname]
+              pokemon.favorite = i[:favorite]
+              pokemon.num_upgrades = i[:num_upgrades]
+              pokemon.battles_attacked = i[:battles_attacked]
+              pokemon.battles_defended = i[:battles_defended]
+              pokemon.pokeball = i[:pokeball]
+              pokemon.height_m = i[:height_m]
+              pokemon.weight_kg = i[:weight_kg]
+              # Save record
+              pokemon.save
+            rescue
             end
-            # Instantiate pokemon
-            pokemon = user.pokemon.new
-            # Set data
-            pokemon.poke_id = poke_id
-            pokemon.poke_num = poke_num
-            pokemon.creation_time_ms = i[:creation_time_ms]
-            pokemon.move_1 = i[:move_1]
-            pokemon.move_2 = i[:move_2]
-            pokemon.health = i[:stamina]
-            pokemon.max_health = i[:stamina_max]
-            pokemon.attack = i[:individual_attack]
-            pokemon.defense = i[:individual_defense]
-            pokemon.stamina = i[:individual_stamina]
-            pokemon.cp = i[:cp]
-            pokemon.iv = ((pokemon.attack + pokemon.defense + pokemon.stamina) / 45.0).round(3)
-            pokemon.nickname = i[:nickname]
-            pokemon.favorite = i[:favorite]
-            pokemon.num_upgrades = i[:num_upgrades]
-            pokemon.battles_attacked = i[:battles_attacked]
-            pokemon.battles_defended = i[:battles_defended]
-            pokemon.pokeball = i[:pokeball]
-            pokemon.height_m = i[:height_m]
-            pokemon.weight_kg = i[:weight_kg]
-            # Save record
-            pokemon.save
           #when :pokemon_family
             #poke_id = i[:family_id].to_s
             #poke_id.slice! 'FAMILY_'


### PR DESCRIPTION
The app started to break as soon as I hatched eggs with gen 2 pokemons. Since I do not know if there is any work in progress regarding the extra pokemons, I did a quick fix just to keep things working as they were.

Here are some tech details
* The expression `i[:pokemon_id].capitalize` in the line 75 (line 76 on my PR) returns a Fixnum instead of a string for gen 2 pokemons. This makes the app break on login.
* A quick fix is to add a `to_s` and make sure capitalize works but that makes the app load an empty page. It looks like the JSON serialization crashes because there are not base stats for gen 2 pokemons in the pokemon model class.
